### PR TITLE
Allow several underscores in statement

### DIFF
--- a/lib/uberscore.rb
+++ b/lib/uberscore.rb
@@ -26,9 +26,16 @@ module Uberscore
     def to_proc
       ->(object) do
         @call_chain.reduce(object) do |block_parameter, (method_name, method_arguments, block)|
+          method_arguments = method_arguments.map{|a| coerce(a, object)}
           block_parameter.public_send(method_name, *method_arguments, &block)
         end
       end
+    end
+
+    private
+
+    def coerce(arg, object)
+      Context === arg ? arg.to_proc.call(object) : arg
     end
   end
 

--- a/spec/uberscore_spec.rb
+++ b/spec/uberscore_spec.rb
@@ -21,4 +21,9 @@ describe Uberscore do
   it "can subscript" do
     expect([{ name: "foo" }, { name: "bar" }].map(&_[:name])).to eq([{ name: "foo" }, { name: "bar" }].map { |hash| hash[:name] })
   end
+
+  it "works with two or more underscores" do
+    expect((_ + _).to_proc.call(3)).to eq 3 + 3
+    expect((_ + _*_).to_proc.call(3)).to eq 3 + 3*3
+  end
 end


### PR DESCRIPTION
Allow those statements to work:

``` ruby
(1...10).map(&_ * 2 + _ ** 2)
# => [3, 8, 15, 24, 35, 48, 63, 80, 99]
```
